### PR TITLE
Add Spotify URLs to stories

### DIFF
--- a/src/_includes/partials/components/intro.njk
+++ b/src/_includes/partials/components/intro.njk
@@ -4,5 +4,8 @@
     {% if introSummary %}
       <div class="[ intro__summary ] [ sf-flow ] [ leading-mid measure-short ]">{{ introSummary | safe }}</div>
     {% endif %}
+    {% if spotify_id %}
+      <iframe src="https://open.spotify.com/embed/track/{{ spotify_id }}" width="320" height="80" frameborder="0" allowtransparency="true"></iframe>
+    {% endif %}
   </div>
 </header>

--- a/src/posts/bockarna-bruse.md
+++ b/src/posts/bockarna-bruse.md
@@ -1,7 +1,7 @@
 ---
 categories: []
 tags: [Sagor från Norge]
-spotify_url: https://open.spotify.com/track/6cbRENjtBkWKgnue4m4NGl?si=Xf-kywuRREKl99dDU7RwhA
+spotify_id: 6cbRENjtBkWKgnue4m4NGl
 title: 'De tre Bockarna Bruse'
 ---
 

--- a/src/posts/bockarna-bruse.md
+++ b/src/posts/bockarna-bruse.md
@@ -1,7 +1,8 @@
 ---
 categories: []
 tags: [Sagor från Norge]
-title: 'Bockarna Bruse'
+spotify_url: https://open.spotify.com/track/6cbRENjtBkWKgnue4m4NGl?si=Xf-kywuRREKl99dDU7RwhA
+title: 'De tre Bockarna Bruse'
 ---
 
 Det var en gång tre bockar, som skulle gå till ängen och äta sig feta. Alla tre hette Bocken Bruse. På vägen var det en bro över en fors, som de måste över, och under den bron bodde ett otäckt troll med ögon som tenntallrikar och näsa lång som ett räfseskaft.

--- a/src/posts/pannkakan.md
+++ b/src/posts/pannkakan.md
@@ -2,6 +2,7 @@
 categories: []
 tags: [Sagor från Norge]
 title: 'Sagan om den tjocka feta Pannkakan'
+spotify_url: https://open.spotify.com/track/2083cW9uY5Ona7hTowMCR6?si=6c8LSmsLQG-J8T07B9RitA
 ---
 
 Det var en gång en bondhustru som hade sju hungriga barn. Och åt dem höll hon på att grädda en pannkaka. Den låg nu i laggen och fräste, så tjock och god att det var en lust att se. Barnen stod runt omkring och gammelfarfar satt och såg på.

--- a/src/posts/pannkakan.md
+++ b/src/posts/pannkakan.md
@@ -2,7 +2,7 @@
 categories: []
 tags: [Sagor från Norge]
 title: 'Sagan om den tjocka feta Pannkakan'
-spotify_url: https://open.spotify.com/track/2083cW9uY5Ona7hTowMCR6?si=6c8LSmsLQG-J8T07B9RitA
+spotify_id: 2083cW9uY5Ona7hTowMCR6
 ---
 
 Det var en gång en bondhustru som hade sju hungriga barn. Och åt dem höll hon på att grädda en pannkaka. Den låg nu i laggen och fräste, så tjock och god att det var en lust att se. Barnen stod runt omkring och gammelfarfar satt och såg på.

--- a/src/posts/pomperipossa.md
+++ b/src/posts/pomperipossa.md
@@ -2,7 +2,7 @@
 categories: []
 tags: [Axel Wallengren, Min Skattkammare]
 title: 'Sagan om Pomperipossa med den långa näsan'
-spotify_url: https://open.spotify.com/track/1ZweyRQzhPyWhbJkKbOe4r?si=-f5LuxY-Q662ocn-6DaZFA
+spotify_id: 1ZweyRQzhPyWhbJkKbOe4r
 ---
 
 Det var en gång för många, många tusen år sen en förfärligt gammal trollpacka, som hette Pomperipossa. Det är inte precis något vackert namn, men ändå är det bra mycket vackrare, än vad hon själv var. Kan ni tänka er, hur hon såg ut? Hon hade två små röda ögon och en stor mun med bara tre tänder i. Och hon hade fullt med vårtor på händerna och en stor puckel på ryggen. Men det värsta var hennes näsa, för den var en hel aln lång. Ni kan tänka er, hur mycket snus, som gick åt, när hon snusade! Ett helt skålpund åt gången!

--- a/src/posts/pomperipossa.md
+++ b/src/posts/pomperipossa.md
@@ -2,6 +2,7 @@
 categories: []
 tags: [Axel Wallengren, Min Skattkammare]
 title: 'Sagan om Pomperipossa med den långa näsan'
+spotify_url: https://open.spotify.com/track/1ZweyRQzhPyWhbJkKbOe4r?si=-f5LuxY-Q662ocn-6DaZFA
 ---
 
 Det var en gång för många, många tusen år sen en förfärligt gammal trollpacka, som hette Pomperipossa. Det är inte precis något vackert namn, men ändå är det bra mycket vackrare, än vad hon själv var. Kan ni tänka er, hur hon såg ut? Hon hade två små röda ögon och en stor mun med bara tre tänder i. Och hon hade fullt med vårtor på händerna och en stor puckel på ryggen. Men det värsta var hennes näsa, för den var en hel aln lång. Ni kan tänka er, hur mycket snus, som gick åt, när hon snusade! Ett helt skålpund åt gången!


### PR DESCRIPTION
Fixes #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Posts can now display an embedded Spotify track when one is associated with the content.
  - Added Spotify tracks to “De tre Bockarna Bruse”, “Pannkakan” and “Pomperipossa”.

- **Content Updates**
  - Updated the title “Bockarna Bruse” to “De tre Bockarna Bruse”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Spotify track embeds to three stories and renames “Bockarna Bruse” to “De tre Bockarna Bruse.”

- Adds conditional Spotify iframe rendering to the shared introduction partial.
- Adds Spotify track IDs to three story front-matter records.
- Updates one story title.

<h3>Confidence Score: 3/5</h3>

The responsive overflow and unnamed iframe should be fixed before merging so the player works correctly for narrow-screen and assistive-technology users.

The player is reachable on all three changed stories, but its fixed width exceeds the available content area on 320px viewports and its missing accessible name makes the embedded content ambiguous to screen readers.

**Files Needing Attention:** src/_includes/partials/components/intro.njk

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/_includes/partials/components/intro.njk | Adds the conditional Spotify player, but its fixed width breaks narrow layouts and it lacks an accessible name. |
| src/posts/bockarna-bruse.md | Adds a Spotify track ID and updates the displayed story title. |
| src/posts/pannkakan.md | Adds a Spotify track ID consumed by the introduction partial. |
| src/posts/pomperipossa.md | Adds a Spotify track ID consumed by the introduction partial. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Asrc%2F_includes%2Fpartials%2Fcomponents%2Fintro.njk%3A8%0A**Fixed-width%20player%20overflows%20mobile%20layout**%0A%0AWhen%20a%20Spotify-enabled%20story%20is%20viewed%20at%20320px%20wide%2C%20the%20wrapper%20leaves%20about%20280px%20of%20content%20space%20but%20this%20iframe%20remains%20320px%20wide%2C%20causing%20horizontal%20overflow%20or%20clipped%20player%20controls.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Ciframe%20src%3D%22https%3A%2F%2Fopen.spotify.com%2Fembed%2Ftrack%2F%7B%7B%20spotify_id%20%7D%7D%22%20width%3D%22320%22%20height%3D%2280%22%20frameborder%3D%220%22%20allowtransparency%3D%22true%22%20style%3D%22max-width%3A%20100%25%22%3E%3C%2Fiframe%3E%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Asrc%2F_includes%2Fpartials%2Fcomponents%2Fintro.njk%3A8%0A**Spotify%20frame%20lacks%20accessible%20name**%0A%0AWhen%20a%20screen-reader%20user%20opens%20any%20of%20these%20Spotify-enabled%20stories%2C%20the%20iframe%20has%20no%20accessible%20name%2C%20causing%20assistive%20technology%20to%20announce%20an%20unnamed%20or%20ambiguous%20frame%20instead%20of%20identifying%20the%20story's%20Spotify%20player.%0A%0A%60%60%60suggestion%0A%20%20%20%20%20%20%3Ciframe%20title%3D%22Listen%20to%20this%20story%20on%20Spotify%22%20src%3D%22https%3A%2F%2Fopen.spotify.com%2Fembed%2Ftrack%2F%7B%7B%20spotify_id%20%7D%7D%22%20width%3D%22320%22%20height%3D%2280%22%20frameborder%3D%220%22%20allowtransparency%3D%22true%22%3E%3C%2Fiframe%3E%0A%60%60%60%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=cybear%2Fsagor.org&pr=8&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
src/_includes/partials/components/intro.njk:8
**Fixed-width player overflows mobile layout**

When a Spotify-enabled story is viewed at 320px wide, the wrapper leaves about 280px of content space but this iframe remains 320px wide, causing horizontal overflow or clipped player controls.

```suggestion
      <iframe src="https://open.spotify.com/embed/track/{{ spotify_id }}" width="320" height="80" frameborder="0" allowtransparency="true" style="max-width: 100%"></iframe>
```

### Issue 2
src/_includes/partials/components/intro.njk:8
**Spotify frame lacks accessible name**

When a screen-reader user opens any of these Spotify-enabled stories, the iframe has no accessible name, causing assistive technology to announce an unnamed or ambiguous frame instead of identifying the story's Spotify player.

```suggestion
      <iframe title="Listen to this story on Spotify" src="https://open.spotify.com/embed/track/{{ spotify_id }}" width="320" height="80" frameborder="0" allowtransparency="true"></iframe>
```

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Change to using spotify\_id"](https://github.com/cybear/sagor.org/commit/39717cb0ecc4b82bd26f837c2b7877807913f056) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52167712)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->